### PR TITLE
make using vagrant and jupyterlab easy

### DIFF
--- a/.jupyter_config.py
+++ b/.jupyter_config.py
@@ -1,0 +1,19 @@
+# Password to use for web authentication
+# the password can be generated with:
+# >>>from notebook.auth import passwd
+# >>>passwd("glotaran")
+# c.NotebookApp.password = u'sha1:deef177aa2dd:657a28dd6c1a12eaf67aa6ab4dfb64166a6ba787'
+
+c.NotebookApp.token = ''
+
+c.NotebookApp.notebook_dir = '/vagrant/tests/notebooks'
+
+
+# Set ip to '*' to bind on all interfaces (ips) for the public server
+c.NotebookApp.ip = '*'
+
+# Don't open browser since vagrant can't read it
+c.NotebookApp.open_browser = False
+
+# It is a good idea to set a known, fixed port for server access
+c.NotebookApp.port = 9999

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,10 +12,10 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/xenial64"
-  
+  config.vm.box = "ubuntu/bionic64"
+
   # Provisioning:
-  config.vm.provision :shell, privileged: false, path: "ubuntu-bootstrap.sh" 
+  config.vm.provision :shell, privileged: false, path: "ubuntu-bootstrap.sh"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -25,7 +25,7 @@ Vagrant.configure(2) do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 8888, host: 8888
+  config.vm.network "forwarded_port", guest: 9999, host: 9999
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -49,7 +49,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     # vb.gui = true
-  
+
     # Customize the amount of memory on the VM:
     vb.memory = "2048"
   end
@@ -69,12 +69,10 @@ Vagrant.configure(2) do |config|
   # documentation for more information about their specific syntax and use.
    config.vm.provision "shell", privileged: false, inline: <<-SHELL
      sudo apt-get update
-     sudo apt-get install -y apache2
    SHELL
-   
+
     config.vm.provision "shell", privileged: false, run: "always", inline: <<-SHELL
-    jupyter notebook --notebook-dir=/vagrant/tests/notebooks --no-browser --ip=0.0.0.0 &
-    sleep 3
+    jupyter lab --config=/vagrant/.jupyter_config.py & sleep 3
     jupyter notebook list
   SHELL
 end

--- a/open_vagrant-jupyter.html
+++ b/open_vagrant-jupyter.html
@@ -1,0 +1,80 @@
+<!--
+Taken from:
+https://stackoverflow.com/questions/4814752/whats-the-best-way-to-check-if-a-website-is-up-or-not-via-javascript
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width, user-scalable=no">
+    <title>Jupyter in vagrant</title>
+    <script>
+    function check_available(){
+        let el=document.getElementById("check_pic");
+		// jupyter notebook image
+        //el.src="http://127.0.0.1:9999/static/base/images/logo.png?now="+Math.random();
+		
+		// jupyter lab image
+		el.src="http://localhost:9999/kernelspecs/python3/logo-64x64.png?now="+Math.random();
+    }
+
+    function check_success(){
+        let url = "http://127.0.0.1:9999";
+        window.location = url;
+        console.log("redirect now :) - url:"+url);
+    }
+    </script>
+    <style>
+        body{
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            padding: 3vmin;
+            margin: 0;
+            position: absolute;
+            }
+        li, footer{
+            font-size: 5vmin;
+            /* list-style: none; */
+            margin-bottom: .5em;
+        }
+        footer{
+            text-align: center;
+            align-self: flex-end;
+        }
+        h1{
+            font-size: 10vmin;
+            text-align: center;
+            margin: 0;
+        }
+        h3{
+            font-size: 8vmin;
+            text-align: left;
+            min-width: 100%;
+            margin-bottom: .5em;
+        }
+    </style>
+</head>
+<body>
+    <img style="visibility:hidden"
+         id='check_pic'
+         src="/images/powered_by.gif"
+         onabort="console.log('interrupted')"
+         onload="check_success()"
+         onerror="check_available()"
+    />
+    <h1>The Jupyter Server run by Vagrant can't be reached</h1>
+    <h3>Possible reasons are:</h3>
+    <ul>
+        <li>You didn't start Vagrant (vagrant up)</li>
+        <li>You started the wrong Vagrant</li>
+        <li>Vagrant didn't finish booting and starting the Jupyter Server yet</li>
+    </ul>
+    <footer>
+        Please visit
+        <a href="https://www.vagrantup.com/">Vagrant</a> or
+        <a href="https://github.com/glotaran/glotaran">glotaran</a> for help.
+    </footer>
+</body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,9 @@ setup(
         'lmfit>=0.9.7',
         'pyyaml',
         'matplotlib',  # dependency introduced by glotaran.plotting
-        'natsort'  # dependency introduced by glotaran.data.io.chlorospec_format
+        'natsort',  # dependency introduced by glotaran.data.io.chlorospec_format
     ],
+	dependency_links=['https://github.com/glotaran/lmfit-varpro.git/tarball/master'],
     cmdclass={"build_ext": build_ext, 'clean': CleanCommand},
     ext_modules=ext_modules,
     test_suite='nose.collector',

--- a/ubuntu-bootstrap.sh
+++ b/ubuntu-bootstrap.sh
@@ -9,7 +9,7 @@ sudo apt-get install git-core -y
 git config --global color.ui true
 
 # Install deps
-sudo apt-get install python3 libfreetype6-dev libpng12-dev python-setuptools python3-dev -y
+sudo apt-get install python3 libfreetype6-dev libpng-dev python-setuptools python3-dev -y
 sudo apt-get install curl -y
 sudo apt-get install tmux -y
 sudo apt-get install build-essential gcc make g++ -y
@@ -26,18 +26,22 @@ pip3 --version
 # sudo apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose -y
 # sudo apt-get install python3-numpy python3-scipy python3-matplotlib ipython ipython3-notebook python3-pandas python3-nose -y
 
+# install dependencies
 sudo -H  pip3 install numpy 
 sudo -H  pip3 install scipy
-sudo -H  pip3 install lmfit 
-sudo -H  pip3 install jupyter
-sudo -H  pip3 install matplotlib
 sudo -H  pip3 install Cython
+
+# sudo -H  pip3 install lmfit 
+# sudo -H  pip3 install matplotlib
 # sudo setfacl -m user:1000:rwx /usr/local/bin
-sudo -H  pip3 install natsort
-sudo -H  pip3 install six
+# sudo -H  pip3 install natsort
+# sudo -H  pip3 install six
+
+# work dependency
+sudo -H  pip3 install jupyterlab
 
 # Install lmfit-varpro (not yet on PyPI - the Python Package Index)
-pip3 install --user git+https://github.com/glotaran/lmfit-varpro.git
+# pip3 install --user git+https://github.com/glotaran/lmfit-varpro.git
 
 # Workaround for Bug
 # sudo ln -s /usr/include/freetype2/ft2build.h /usr/include/ft2build.h


### PR DESCRIPTION
This PR concerns the issues #74 and  #73.

I updated the Vagrantfile to use ubuntu 18.04 LTS and use jupyterlab instead of notebooks.
I also removed some redundant package installations in ubuntu-bootstrap.sh and moved the installation of lmfit-varpro to setup.py (one step closer to a PYPI package).

For jupyterlab on vagrant not to conflict with possible running jupyter instances of users with default config, I can changed port 8888 to 9999 (over 9000 :P ) and removed the authetication token.
Thus a user now can just run "vagrant up" and click on "open_vagrant-jupyter.html" to get to jupyterlab or get a list with possible reasons why he/she isn't redirected.
Feel free to pretty up "open_vagrant-jupyter.html" with some css.