### PR TITLE
Make pip+git install possible

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,7 +38,7 @@ Afterwards you can simply use `pip`_ to install it directly from the `Github rep
 
 .. code-block:: console
 
-    $ pip install git+https://github.com/glotaran/glotaran.git@develop
+    $ pip install git+https://github.com/glotaran/glotaran.git@develop --process-dependency-links
 
 Or you can either clone the public repository:
 

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ setup(
         'pyyaml',
         'matplotlib',  # dependency introduced by glotaran.plotting
         'natsort',  # dependency introduced by glotaran.data.io.chlorospec_format
-        'lmfit-varpro'
+        'lmfit-varpro>=0.1.0'
     ],
-	dependency_links=['https://github.com/glotaran/lmfit-varpro/tarball/master#egg=lmfit-varpro'],
+	dependency_links=['https://github.com/glotaran/lmfit-varpro/tarball/master#egg=lmfit-varpro-0.1.0'],
     cmdclass={"build_ext": build_ext, 'clean': CleanCommand},
     ext_modules=ext_modules,
     test_suite='nose.collector',


### PR DESCRIPTION
Following this [stackowerflow question](https://stackoverflow.com/questions/12518499/pip-ignores-dependency-links-in-setup-py#13587734) I added a version to the lmfit-varpro dependency and dependency_link, which makes it possible to install glotaran by running:

``pip install git+https://github.com/glotaran/glotaran.git@develop --process-dependency-links``

I tested it with this branch, [see](https://github.com/s-weigand/quickstart).