### PR TITLE
added readthedocs.yml, so python 3.6 will be used for building the docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+
+python:
+  version: 3.6
+  setup_py_install: true


### PR DESCRIPTION
Added a  [``readthedocs.yml``](https://docs.readthedocs.io/en/latest/yaml-config.html) so readthedocs uses python 3.6 to build the documentation.

**Closing issues**

closes #107 
