### PR TITLE
Fix failing travis builds #42 and #43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
   - echo "check clean old c files"
   - ls -la glotaran/models/spectral_temporal/c_matrix_cython/
   - pip install coveralls
-  - pip install -r requirements_dev.txt
+  - pip install -U -r requirements_dev.txt
 
 script:
   - pwd

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,6 +18,7 @@ sphinx-rtd-theme>=0.3.1
 # testing dependencies
 tox>=3.0.0
 flake8>=3.5.0
-pytest>=3.4.2
-pytest-cov
+pytest>=3.7.1
+pluggy>=0.7
+pytest-cov>=2.5.1
 pytest-runner>=2.11.1


### PR DESCRIPTION
* added ``pluggy>=0.7`` (needed for pytest) to `requirements_dev.txt`
* Made dev requirements installation on travis update requirements

This should fix the problems with travis
