### PR TITLE
change py37-dev to current python 3.7 for travis tests on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,10 @@ matrix:
     - python: "3.6"
       env: linux-py36
 
-    - python: "3.7-dev"  # 3.7 development branch
+    - language: python
+      sudo: required
+      dist: xenial
+      python: "3.7"
       env: linux-py37
 
     # OSX


### PR DESCRIPTION
Changed deprecated 'py37-dev' test to current python 3.7, for travis tests on linux.

**Note:**  flake8 will fail see #164 

**Closing issues**

closes #165
